### PR TITLE
add missing token to npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,3 +15,5 @@ jobs:
       - run: npm run test
       - run: npm run build
       - run: npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Need to specify the token when publishing.

BE-2133