### PR TITLE
[BE-2133] set npm token correctly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
       - run: npm ci
       - run: npm run test
       - run: npm run build
-      - run: npm publish
+      - run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+          npm publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
NPM does not look at the environment for the token, but looks for various `.npmrc` files to determine how and where and who to publish.
We create one on the root to specify the token to use and registry to publish to.

BE-2133